### PR TITLE
Default projector file

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -16,15 +16,18 @@ const cli = meow(`
 `);
 
 let {input, flags} = cli;
+let [projectorFile, projectorTask] = input;
 
-if (input.length !== 2) {
+if (input.length === 0) {
   cli.showHelp();
+} else if (input.length === 1) {
+  projectorTask = projectorFile;
+  projectorFile = './projector.js';
 }
 
-let generator = resolveFrom(process.cwd(), input[0]);
-let task = input[1];
+let generator = resolveFrom(process.cwd(), projectorFile);
 
-projector(generator, task, [flags]).then(result => {
+projector(generator, projectorTask, [flags]).then(result => {
   if (result !== undefined) console.log(JSON.stringify(result));
 }).catch(err => {
   console.error(err);

--- a/projector-custom.js
+++ b/projector-custom.js
@@ -1,0 +1,1 @@
+module.exports = require('./projector');

--- a/projector.js
+++ b/projector.js
@@ -1,0 +1,13 @@
+exports.SUCCESS = async (opts = {}) => {
+  return { opts };
+};
+
+exports.FAILURE = async (opts = {}) => {
+  throw new Error('Oops');
+};
+
+exports.UNSERIALIZABLE = async (opts = {}) => {
+  let obj = {};
+  obj.obj = obj;
+  return obj;
+};

--- a/test.js
+++ b/test.js
@@ -5,8 +5,8 @@ const child = require('child_process');
 const path = require('path');
 const bin = path.join(__dirname, 'bin.js');
 
-function exec(command) {
-  return child.execSync(`${bin} ./fixture.js ${command}`, { stdio: 'pipe' }).toString();
+function exec(command, script = '') {
+  return child.execSync(`${bin} ${script} ${command}`, { stdio: 'pipe' }).toString();
 }
 
 test('success', () => {
@@ -19,4 +19,8 @@ test('failure', () => {
 
 test('unserializable', () => {
   expect(() => { exec('UNSERIALIZABLE'); }).toThrow('Converting circular structure to JSON');
+});
+
+test('custom projector file', () => {
+  expect(JSON.parse(exec('SUCCESS --foo 1', './projector-custom.js'))).toEqual({ opts: { foo: 1 } });
 });


### PR DESCRIPTION
- Refactor test to use new default `./projector.js` file.
- Add new test to test for a custom projector file.
- Update bin script to use a default projector file if one is not provided.